### PR TITLE
setup.py is fixed: textable is texttable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     keywords = "django",
     description = "Performance logging middlware and analysis tools for Django",
     install_requires=[
-        'textable',
+        'texttable',
         'progressbar',
     ],
     classifiers = [


### PR DESCRIPTION
The release on pypi is broken because of this incorrect requirement.

Thanks for the useful app!
