### PR TITLE
Gracefully handle missing '_start' attribute

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from setuptools import setup, find_packages
 
 setup(
@@ -6,7 +7,7 @@ setup(
     author = "Gareth Rushgrove",
     author_email = "gareth@morethanseven.net",
     url = "http://github.com/garethr/django-timelog/",
-    
+
     packages = find_packages('src'),
     package_dir = {'':'src'},
     license = "MIT License",

--- a/src/timelog/middleware.py
+++ b/src/timelog/middleware.py
@@ -11,9 +11,15 @@ class TimeLogMiddleware(object):
         request._start = time.time()
 
     def process_response(self, request, response):
-        d = {'method': request.method, 'time': time.time() - request._start,
-             'code': response.status_code,
-             'url': smart_str(request.path_info)}
-        msg = '%(method)s "%(url)s" (%(code)s) %(time).2f' % d
-        logger.info(msg)
+        # if an exception is occured in a middleware listed
+        # before TimeLogMiddleware then request won't have '_start' attribute
+        # and the original traceback will be lost (original exception will be
+        # replaced with AttributeError)
+        if hasattr(request, '_start'):
+            d = {'method': request.method,
+                 'time': time.time() - request._start,
+                 'code': response.status_code,
+                 'url': smart_str(request.path_info)}
+            msg = '%(method)s "%(url)s" (%(code)s) %(time).2f' % d
+            logger.info(msg)
         return response


### PR DESCRIPTION
Sometimes it make sense to not put TimeLogMiddleware as the first middleware, and in such cases TimeLogMiddleware can't be sure the process_request method is executed.

My case was an incorrect admin configuration and the 'debug_toolbar.middleware.DebugToolbarMiddleware' inserted before TimeLogMiddleware. Instead of ImproperlyConfigured exception AttributeError is raised without this patch. 
