### PR TITLE
Adding support for the OPTIONS http method

### DIFF
--- a/src/timelog/lib.py
+++ b/src/timelog/lib.py
@@ -7,7 +7,7 @@ from progressbar import ProgressBar, Percentage, Bar
 
 from django.core.urlresolvers import resolve, Resolver404
 
-PATTERN = r"""^([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9:]{8},[0-9]{3}) (GET|POST|PUT|DELETE|HEAD) "(.*)" \((.*)\) (.*?) \((\d+)q, (.*?)\)"""
+PATTERN = r"""^([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9:]{8},[0-9]{3}) (GET|POST|PUT|DELETE|HEAD|OPTIONS) "(.*)" \((.*)\) (.*?) \((\d+)q, (.*?)\)"""
 
 CACHED_VIEWS = {}
 


### PR DESCRIPTION
Hi,

This request is so that when we have the OPTIONS http verb in our timelog log, we don't see python errors. This update fixes the python errors by adding OPTIONS as one of the supported entries in the pattern.

Regards,
Mark
